### PR TITLE
Bug fixes and improvements

### DIFF
--- a/Example/App.config
+++ b/Example/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/Example/Example.csproj
+++ b/Example/Example.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Example</RootNamespace>
     <AssemblyName>Example</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>

--- a/Spitfire/DataChannelObserver.cpp
+++ b/Spitfire/DataChannelObserver.cpp
@@ -20,20 +20,10 @@ void Spitfire::Observers::DataChannelObserver::OnBufferedAmountChange(uint64_t p
 
 void Spitfire::Observers::DataChannelObserver::OnMessage(const webrtc::DataBuffer & buffer)
 {
-	if (buffer.binary)
+
+	if (conductor_->onMessage)
 	{
-		if (conductor_->onDataBinaryMessage)
-		{
-			auto * data = buffer.data.data();
-			conductor_->onDataBinaryMessage(dataChannel->label().c_str(), data, static_cast<uint32_t>(buffer.size()));
-		}
-	}
-	else
-	{
-		if (conductor_->onDataMessage)
-		{
-			std::string msg(buffer.data.data<char>(), buffer.size());
-			conductor_->onDataMessage(dataChannel->label().c_str(), msg.c_str());
-		}
+		auto* data = buffer.data.data();
+		conductor_->onMessage(dataChannel->label().c_str(), data, static_cast<uint32_t>(buffer.size()), buffer.binary);
 	}
 }

--- a/Spitfire/Spitfire.vcxproj
+++ b/Spitfire/Spitfire.vcxproj
@@ -19,11 +19,12 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{5950B9B8-D486-4B8B-A3A1-53F1738F45ED}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Spitfire</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
- Actually release handles that were being left open even after disposing of the Spitfire context
- Remove allocations from the send and receive data channel functions. We now pass pointers so data can be read and sent via Span<T>
- Add the ability to close a data channel
- Properly create threads without immediate releases
- Remove / simplify some calls / events